### PR TITLE
Support extra tags for libkomwm

### DIFF
--- a/src/libkomwm.py
+++ b/src/libkomwm.py
@@ -5,6 +5,7 @@ import csv
 import sys
 import itertools
 from multiprocessing import Pool
+from collections import OrderedDict
 import mapcss.webcolors
 whatever_to_hex = mapcss.webcolors.webcolors.whatever_to_hex
 whatever_to_cairo = mapcss.webcolors.webcolors.whatever_to_cairo
@@ -183,7 +184,7 @@ def komap_mapswithme(options):
         if cl in unique_types_check and row[2] != 'x':
             raise Exception('Duplicate type: {0}'.format(row[0]))
         pairs = [i.strip(']').split("=") for i in row[1].split(',')[0].split('[')]
-        kv = {}
+        kv = OrderedDict()
         for i in pairs:
             if len(i) == 1:
                 if i[0]:
@@ -209,10 +210,12 @@ def komap_mapswithme(options):
     types_file.close()
 
     # Get all mapcss static tags which are used in mapcss-mapping.csv
-    mapcss_static_tags = set()
+    # This is a dict with main_tag flags (True = appears first in types)
+    mapcss_static_tags = {}
     for v in classificator.values():
-        for t in v.keys():
-            mapcss_static_tags.add(t)
+        for i, t in enumerate(v.keys()):
+            # Exception for "sport=*" since these are both main and secondary keys.
+            mapcss_static_tags[t] = i == 0 and t != 'sport'
 
     # Get all mapcss dynamic tags from mapcss-dynamic.txt
     mapcss_dynamic_tags = set([line.rstrip() for line in open(os.path.join(ddir, 'mapcss-dynamic.txt'))])
@@ -220,7 +223,8 @@ def komap_mapswithme(options):
     # Parse style mapcss
     global style
     style = MapCSS(options.minzoom, options.maxzoom + 1)
-    style.parse(filename = options.filename, static_tags = mapcss_static_tags, dynamic_tags = mapcss_dynamic_tags)
+    style.parse(filename=options.filename, static_tags=mapcss_static_tags,
+                dynamic_tags=mapcss_dynamic_tags)
 
     # Build optimization tree - class/type -> StyleChoosers
     for cl in class_order:

--- a/src/libkomwm.py
+++ b/src/libkomwm.py
@@ -214,8 +214,7 @@ def komap_mapswithme(options):
     mapcss_static_tags = {}
     for v in classificator.values():
         for i, t in enumerate(v.keys()):
-            # Exception for "sport=*" since these are both main and secondary keys.
-            mapcss_static_tags[t] = i == 0 and t != 'sport'
+            mapcss_static_tags[t] = mapcss_static_tags.get(t, True) and i == 0
 
     # Get all mapcss dynamic tags from mapcss-dynamic.txt
     mapcss_dynamic_tags = set([line.rstrip() for line in open(os.path.join(ddir, 'mapcss-dynamic.txt'))])

--- a/src/mapcss/Condition.py
+++ b/src/mapcss/Condition.py
@@ -79,9 +79,9 @@ class Condition:
         if t == 'eq':
             return "%s=%s" % (params[0], params[1])
         if t == 'ne':
-            return "%s=%s" % (params[0], params[1])
+            return "%s!=%s" % (params[0], params[1])
         if t == 'regex':
-            return "%s=~/%s/" % (params[0], params[1]);
+            return "%s=~/%s/" % (params[0], params[1])
         if t == 'true':
             return "%s?" % (params[0])
         if t == 'untrue':


### PR DESCRIPTION
Что здесь происходит: сначала мы сортируем «статические» теги (т.е. входящие в классификатор) на основные и второстепенные. Например, для `[leisure=pitch][sport=soccer]` внутри первых квадратных скобок основной тег, внутри вторых — второстепенный. Принцип именно по последовательности, поэтому dict я заменил на `OrderedDict`.

Далее, в парсере в основные селекторы берём только первый основной тег и все второстепенные. А второй и последующий основные теги запихиваем в `runtime_selectors` (и далее в `apply_if`) в виде `[extra_tag=key=value]` или `[extra_tag!=key=value]`. Разумеется, теги без значений (`[extra_tag=key]`) тоже позволены.

Это позволит проверять в стилях на наличие двух и более типов одновременно: например, подсвечивать только букинговские гостиницы и игнорировать букинговские апартаменты.