### PR TITLE
Mark original type to distinguish it among replacing types.

### DIFF
--- a/src/libkomwm.py
+++ b/src/libkomwm.py
@@ -198,7 +198,8 @@ def komap_mapswithme(options):
             classificator[cl] = kv
             class_order.append(cl)
             unique_types_check.add(cl)
-            print >> types_file, row[0]
+            # Mark original type to distinguish it among replacing types.
+            print >> types_file, "*" + row[0]
         else:
             # compatibility mode
             if row[6]:


### PR DESCRIPTION
Сейчас у нас могу ехать индексы типов, что крайне нежелательно, т.к. мы полагаемся на то что они не едут, см. описание https://github.com/mapsme/omim/pull/12660

Предлагаю помечать оригинальные типы и при парсинге types.txt использовать для GetIndexForType только оригинальные типы. Это сделает индексы стабильными независимо от deprecate-ов.